### PR TITLE
InputDispatcher: extend "do not freeze recent on event from FOD and s…

### DIFF
--- a/services/inputflinger/dispatcher/InputDispatcher.cpp
+++ b/services/inputflinger/dispatcher/InputDispatcher.cpp
@@ -1189,8 +1189,8 @@ bool InputDispatcher::dispatchKeyLocked(nsecs_t currentTime, KeyEntry* entry,
     // Give the policy a chance to intercept the key.
     if (entry->interceptKeyResult == KeyEntry::INTERCEPT_KEY_RESULT_UNKNOWN) {
         if (entry->policyFlags & POLICY_FLAG_PASS_TO_USER) {
-            // Key from fingerprint sensor
-            if(entry->keyCode == 0 && (entry->scanCode == 338 || entry->scanCode == 96)){
+            // Key from fingerprint sensor/xiaomi-touch
+            if(entry->keyCode == 0 && (entry->scanCode == 338 || entry->scanCode == 96 || entry->scanCode == 339)){
                 entry->interceptKeyResult = KeyEntry::INTERCEPT_KEY_RESULT_SKIP;
                 *dropReason = DropReason::POLICY;
                 ALOGI("Key from FOD");


### PR DESCRIPTION
…ide FP" to xiaomi-touch event

fixes ANR/Scrolling issues on devices like apollo/pro

Signed-off-by: Sandepp Sethi <adeveloper79@gmail.com>