### PR TITLE
blur: Don't limit number of Kawase blur passes

### DIFF
--- a/libs/renderengine/gl/filters/BlurFilter.cpp
+++ b/libs/renderengine/gl/filters/BlurFilter.cpp
@@ -131,8 +131,7 @@ status_t BlurFilter::prepare() {
     const auto radius = mRadius / 6.0f;
 
     // Calculate how many passes we'll do, based on the radius.
-    // Too many passes will make the operation expensive.
-    const auto passes = min(kMaxPasses, (uint32_t)ceil(radius));
+    const auto passes = max((uint32_t)1, (uint32_t)ceil(radius));
 
     const float radiusByPasses = radius / (float)passes;
     const float stepX = radiusByPasses / (float)mCompositionFbo.getBufferWidth();

--- a/libs/renderengine/gl/filters/BlurFilter.h
+++ b/libs/renderengine/gl/filters/BlurFilter.h
@@ -37,8 +37,6 @@ class BlurFilter {
 public:
     // Downsample FBO to improve performance
     static constexpr float kFboScale = 0.25f;
-    // Maximum number of render passes
-    static constexpr uint32_t kMaxPasses = 4;
     // To avoid downscaling artifacts, we interpolate the blurred fbo with the full composited
     // image, up to this radius.
     static constexpr float kMaxCrossFadeRadius = 30.0f;


### PR DESCRIPTION
Limiting the number of passes results in a very low quality blur scene
covered with diagonal Kawase blur artifacts. It also causes some radii
to result in less blur than desired due to the increased diffusion not
being able to compensate for the insufficient number of passes.

Signed-off-by: Danny Lin <danny@kdrag0n.dev>